### PR TITLE
Skip scenarios lacking required desktop capability

### DIFF
--- a/test/features/support/env.rb
+++ b/test/features/support/env.rb
@@ -1,5 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "matrix"
+
+VARIANT = begin
+  img = ENV["BASE_IMAGE"] || ENV["IMAGE_NAME"] || ENV["VARIANT"]
+  if img
+    base = img.split("/").last.split(":").first.sub(/-howdy$/, "")
+    { base: base.to_sym }
+  end
+end
+
+Before do |scenario|
+  if scenario.source_tag_names.include?("@gnome") &&
+     !(VARIANT && has?(VARIANT, :gdm))
+    skip_this_scenario("Skipping @gnome scenario for image without GNOME")
+  end
+end
+
 After do
   if @mock_tag
     Container.cleanup!(@mock_tag)
   end
 end
+


### PR DESCRIPTION
## Summary
- detect container variant from environment
- skip @gnome scenarios when the image doesn't include GNOME support

## Testing
- `BASE_IMAGE=ghcr.io/ublue-os/bazzite-kde:gts bundle exec cucumber --require test/features --tags @gnome test/features/howdy.feature -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc8372c4c48321bffa6f21df544634