### PR TITLE
Support GDM and SDDM in howdy-pam-add

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -19,42 +19,62 @@ ts := `date +%Y%m%d-%H%M%S`
 # PAM paths and line to insert
 
 GDM_PAM := "/etc/pam.d/gdm-password"
+SDDM_PAM := "/etc/pam.d/sddm"
 HOWDY_LINE := "auth sufficient pam_howdy.so"
 
 # Add Howdy to GDM and/or sudo; interactive, idempotent, with backups
 howdy-pam-add:
     #!/usr/bin/env bash
     set -euo pipefail
+    has_gdm=0
+    has_sddm=0
+    [[ -f "{{GDM_PAM}}" ]] && has_gdm=1
+    [[ -f "{{SDDM_PAM}}" ]] && has_sddm=1
+    if [[ $has_gdm -eq 0 && $has_sddm -eq 0 ]]; then
+        echo "Note: neither {{GDM_PAM}} nor {{SDDM_PAM}} found; skipping greeter integration."
+        exit 0
+    fi
     echo "!!! WARNING !!!"
-    echo "This modifies PAM. TEST GNOME LOGIN AT THE GREETER BEFORE REBOOTING."
-    echo "If the greeter fails: Ctrl+Alt+F3 -> login -> 'ujust howdy-pam-revert' -> 'sudo systemctl restart gdm'"
-    # --- GDM (interactive, no-op if already present) ---
-    read -p "Add Howdy to GDM login ({{GDM_PAM}})? [y/N]: " -n 1 -r; echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        if grep -q 'pam_howdy\.so' "{{GDM_PAM}}"; then
-            echo "Howdy already present in {{GDM_PAM}}; skipping."
-        else
-            just sudoif cp -a "{{GDM_PAM}}" "{{GDM_PAM}}.bak.{{ts}}"
-            if grep -q 'pam_selinux_permit\.so' "{{GDM_PAM}}"; then
-                awk -v ins='{{HOWDY_LINE}}' '
-                { print }
-                $0 ~ /pam_selinux_permit\.so/ { print ins }
-                ' "{{GDM_PAM}}" > /tmp/gdm-password.new
+    echo "This modifies PAM. TEST LOGIN AT THE GREETER BEFORE REBOOTING."
+    echo "If the greeter fails: Ctrl+Alt+F3 -> login -> 'ujust howdy-pam-revert' -> 'sudo systemctl restart gdm or sddm'"
+    insert_pam() {
+        local pam_file="$1"; shift
+        local label="$1"; shift
+        read -p "Add Howdy to ${label} login (${pam_file})? [y/N]: " -n 1 -r; echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            if grep -q 'pam_howdy\.so' "${pam_file}"; then
+                echo "Howdy already present in ${pam_file}; skipping."
             else
-                awk -v ins='{{HOWDY_LINE}}' '
-                NR==1 && $0 ~ /^#%PAM-1\.0/ { print; print ins; next }
-                { print }
-                ' "{{GDM_PAM}}" > /tmp/gdm-password.new
-            fi
-            if [ -f "{{GDM_PAM}}" ]; then
-                just sudoif install -m 0644 /tmp/gdm-password.new "{{GDM_PAM}}"
-                just sudoif restorecon -v "{{GDM_PAM}}" || true
-                rm -f /tmp/gdm-password.new
-                echo "Inserted Howdy into {{GDM_PAM}}"
-            else
-                echo "Note: {{GDM_PAM}} not found; skipping GDM integration on this system."
+                just sudoif cp -a "${pam_file}" "${pam_file}.bak.{{ts}}"
+                local tmpfile
+                tmpfile="$(mktemp)"
+                if grep -q 'pam_selinux_permit\.so' "${pam_file}"; then
+                    awk -v ins='{{HOWDY_LINE}}' '
+                    { print }
+                    $0 ~ /pam_selinux_permit\.so/ { print ins }
+                    ' "${pam_file}" > "${tmpfile}"
+                else
+                    awk -v ins='{{HOWDY_LINE}}' '
+                    NR==1 && $0 ~ /^#%PAM-1\.0/ { print; print ins; next }
+                    { print }
+                    ' "${pam_file}" > "${tmpfile}"
+                fi
+                if [ -f "${pam_file}" ]; then
+                    just sudoif install -m 0644 "${tmpfile}" "${pam_file}"
+                    just sudoif restorecon -v "${pam_file}" || true
+                    rm -f "${tmpfile}"
+                    echo "Inserted Howdy into ${pam_file}"
+                else
+                    echo "Note: ${pam_file} not found; skipping ${label} integration on this system."
+                fi
             fi
         fi
+    }
+    if [[ $has_gdm -eq 1 ]]; then
+        insert_pam "{{GDM_PAM}}" "GDM"
+    fi
+    if [[ $has_sddm -eq 1 ]]; then
+        insert_pam "{{SDDM_PAM}}" "SDDM"
     fi
 
     # --- sudo (interactive, no-op if already present) ---
@@ -100,7 +120,7 @@ howdy-pam-revert:
     else
         echo "No backup found for /etc/pam.d/sudo"
     fi
-    echo "Done. You may run: sudo systemctl restart gdm"
+    echo "Done. You may run: sudo systemctl restart gdm or sddm"
 
 @howdy-camera-picker:
     #!/usr/bin/env bash

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sudo bootc switch ghcr.io/rall/bluefin-dx-nvidia-open-howdy:gts
 ```
 Other variants exist (`bluefin-howdy`, `bluefin-dx-howdy`, `bluefin-nvidia-howdy`) with `gts` or `latest` tags.
 
-2. Configure PAM (adds Howdy to GDM, optional prompt for sudo):
+2. Configure PAM (adds Howdy to GDM or SDDM, optional prompt for sudo):
 
 ```
 ujust howdy-pam-add
@@ -37,7 +37,7 @@ If the greeter fails after changes:
 ```
 Ctrl+Alt+F3
 ujust howdy-pam-revert
-sudo systemctl restart gdm
+sudo systemctl restart gdm or sddm
 ```
 
 3. Pick the right camera interactively:
@@ -48,7 +48,7 @@ ujust howdy-camera-picker
 
 4. Lock the screen or switch user to test face login at the greeter.
 
-5. If GDM login works with `sudo howdy test` but fails at the greeter, repair SELinux:
+5. If login works with `sudo howdy test` but fails at the greeter, repair SELinux:
 
 ```
 ujust howdy-selinux-repair-start
@@ -69,7 +69,7 @@ This repo adds Justfile tasks for configuring PAM, selecting the Howdy camera, a
 
 ### PAM helpers
 
-- Add Howdy to GDM and / or sudo:
+- Add Howdy to the login greeter (GDM or SDDM) and / or sudo:
 
 ```
 ujust howdy-pam-add
@@ -86,7 +86,7 @@ Every `howdy-pam-add` run makes timestamped backups of the PAM file(s). If the g
 ```
 Ctrl+Alt+F3
 ujust howdy-pam-revert
-sudo systemctl restart gdm
+sudo systemctl restart gdm or sddm
 ```
 
 **<span style="color:red">To avoid potential lock-out, make sure you verify the changes made to your pam.d config before rebooting</span>**
@@ -145,7 +145,7 @@ sudo bootc switch localhost/blue-howdy:gts
 
 ## Troubleshooting
 
-- **Howdy works for sudo but not GDM login**: it's possible your SELinux policy module store is corrupted. See **SELinux repair,** above
+- **Howdy works for sudo but not at the greeter**: it's possible your SELinux policy module store is corrupted. See **SELinux repair,** above
 
 - **Howdy prompts missing**: run `just howdy-pam-add` to (re)insert PAM lines; it will no-op if they’re already present.
 


### PR DESCRIPTION
## Summary
- detect GDM and SDDM PAM files before prompting
- add SDDM insertion logic to `howdy-pam-add`
- document that the task now handles GDM or SDDM
- refactor greeter insertion into a reusable function

## Testing
- `bundle exec cucumber test/features`


------
https://chatgpt.com/codex/tasks/task_e_68bce559e04c832199e42c38daeadb80