### PR TITLE
Fix Howdy SELinux repair for immutable roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,14 @@ If the SELinux module store gets corrupted (e.g. AVCs show `{ map }` denials for
 ujust howdy-selinux-repair
 ```
 
-This will relabel the SELinux store, rebuild modules, reinstall the `howdy_gdm` policy from the image, and verify it is loaded.
+ The task relabels the SELinux store, rebuilds modules, compiles the policy under `/var/lib/howdy-selinux`, installs it, and verifies `howdy_gdm` is loaded.
+
+Verify and test:
+
+```
+sudo semodule -l | grep howdy_gdm
+sudo -u gdm howdy test
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- compile SELinux policy under `/var/lib/howdy-selinux` to avoid read-only errors
- run installed `howdy-selinux-setup` helper before falling back to manual compilation
- document new repair path and verification steps

## Testing
- `shellcheck -s bash - <<'EOF' ... EOF`


------
https://chatgpt.com/codex/tasks/task_e_68c5d887af988321bd291dc8c85a2e84