### PR TITLE
Move PAM add logic into howdy-pam task

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -23,7 +23,7 @@ SDDM_PAM := "/etc/pam.d/sddm"
 HOWDY_LINE := "auth sufficient pam_howdy.so"
 
 # Add Howdy to GDM, SDDM and/or sudo; interactive + idempotent
-howdy-pam-add:
+howdy-pam:
   #!/usr/bin/env bash
   set -euo pipefail
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Other variants exist (`bluefin-howdy`, `bluefin-dx-howdy`, `bluefin-nvidia-howdy
 2. Configure PAM (adds Howdy to GDM or SDDM, optional prompt for sudo):
 
 ```
-ujust howdy-pam-add
+ujust howdy-pam
 ```
 
 If the greeter fails after changes:
@@ -72,7 +72,7 @@ This repo adds Justfile tasks for configuring PAM, selecting the Howdy camera, a
 - Add Howdy to the login greeter (GDM or SDDM) and / or sudo:
 
 ```
-ujust howdy-pam-add
+ujust howdy-pam
 ```
 
 - Revert PAM files to the most recent backups:
@@ -81,7 +81,7 @@ ujust howdy-pam-add
 ujust howdy-pam-revert
 ```
 
-Every `howdy-pam-add` run makes timestamped backups of the PAM file(s). If the greeter fails:
+Every `howdy-pam` run makes timestamped backups of the PAM file(s). If the greeter fails:
 
 ```
 Ctrl+Alt+F3
@@ -144,6 +144,6 @@ sudo bootc switch localhost/blue-howdy:gts
 
 - **Howdy works for sudo but not at the greeter**: it's possible your SELinux policy module store is corrupted. See **SELinux repair,** above
 
-- **Howdy prompts missing**: run `just howdy-pam-add` to (re)insert PAM lines; it will no-op if they’re already present.
+- **Howdy prompts missing**: run `just howdy-pam` to (re)insert PAM lines; it will no-op if they’re already present.
 
 - **Howdy unlocks my session, but I still have to enter my password to unlock the login keyring**: This is expected — PAM doesn't have your password so it can't pass it along to the GNOME Keyring. You could avoid this by blanking the keyring password with [Seahorse](https://wiki.gnome.org/Apps/Seahorse)

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -12,7 +12,7 @@ When(/I run 'ujust howdy-pam-add' (to|but don't) add howdy to (login|sudo)/) do 
     :"Add Howdy to sudo" => (pam == "sudo"  ? "y" : "n"),
     :"Proceed?" => "y",
   }
-  run_command(container.exec_cmd("ujust howdy-pam-add", interactive: true, root: true))
+  run_command(container.exec_cmd("ujust howdy-pam", interactive: true, root: true))
   until last_command_started.output.include?("Done. Now lock your session or switch user to test the greeter.")
     answers.each do |k, v|
       if last_command_started.output.include?(k.to_s)


### PR DESCRIPTION
## Summary
- move the interactive PAM configuration recipe into the `howdy-pam` task as the sole entry point
- drop the `howdy-pam-add` alias and update the README to reference only `ujust howdy-pam`
- restore the cucumber feature wording while keeping the step definition invoking `ujust howdy-pam`

## Testing
- `bundle exec cucumber` *(fails: container engine not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b3956d8483218325f6faa61e2feb