### PR TITLE
Rename SELinux policy module to display manager neutral name

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,7 @@ RUN rpm-ostree install policycoreutils selinux-policy-targeted checkpolicy \
 
 COPY selinux/howdy-selinux-setup /usr/libexec/howdy-selinux-setup
 RUN chmod 0755 /usr/libexec/howdy-selinux-setup
-COPY selinux/howdy_gdm.te /usr/share/selinux/howdy/howdy_gdm.te
+COPY selinux/howdy_dm.te /usr/share/selinux/howdy/howdy_dm.te
 COPY systemd/howdy-selinux-install.service /usr/lib/systemd/system/howdy-selinux-install.service
 RUN ln -s ../howdy-selinux-install.service \
     /usr/lib/systemd/system/multi-user.target.wants/howdy-selinux-install.service

--- a/selinux/howdy-selinux-setup
+++ b/selinux/howdy-selinux-setup
@@ -19,25 +19,25 @@ if ! sestatus >/dev/null 2>&1 || ! sestatus 2>/dev/null | grep -q 'enabled'; the
 fi
 
 # Exit if already installed
-if "$SEM" -l | awk '{print $1}' | grep -qx howdy_gdm; then
+if "$SEM" -l | awk '{print $1}' | grep -qx howdy_dm; then
   exit 0
 fi
 
 install -d -m0755 "$WRK"
-cp -f "/usr/share/selinux/howdy/howdy_gdm.te" "$WRK/"
+cp -f "/usr/share/selinux/howdy/howdy_dm.te" "$WRK/"
 
 # Prefer devel Makefile; else fall back to raw toolchain (module ver 21)
 if [ -f /usr/share/selinux/devel/Makefile ]; then
   log "building via devel Makefile"
-  make -s -f /usr/share/selinux/devel/Makefile -C "$WRK" howdy_gdm.pp
+  make -s -f /usr/share/selinux/devel/Makefile -C "$WRK" howdy_dm.pp
 else
   log "building via checkmodule/semodule_package (c=21)"
-  checkmodule -M -m -c 21 -o "$WRK/howdy_gdm.mod" "$WRK/howdy_gdm.te"
-  semodule_package -o "$WRK/howdy_gdm.pp" -m "$WRK/howdy_gdm.mod"
+  checkmodule -M -m -c 21 -o "$WRK/howdy_dm.mod" "$WRK/howdy_dm.te"
+  semodule_package -o "$WRK/howdy_dm.pp" -m "$WRK/howdy_dm.mod"
 fi
 
 # Try to install the compiled module
-if "$SEM" -i "$WRK/howdy_gdm.pp" 2>/dev/null; then
+if "$SEM" -i "$WRK/howdy_dm.pp" 2>/dev/null; then
   log "installed TE module"
   exit 0
 fi
@@ -47,7 +47,7 @@ if command -v ausearch >/dev/null && command -v audit2allow >/dev/null; then
   (ausearch -m avc -ts boot || ausearch -m avc -ts recent) > "$WRK/howdy.avc" || true
   if [ -s "$WRK/howdy.avc" ]; then
     log "installing AVC-derived module"
-    audit2allow -M howdy_gdm_auto -i "$WRK/howdy.avc" && "$SEM" -X 400 -i howdy_gdm_auto.pp || true
+    audit2allow -M howdy_dm_auto -i "$WRK/howdy.avc" && "$SEM" -X 400 -i howdy_dm_auto.pp || true
   fi
 fi
 

--- a/selinux/howdy_dm.te
+++ b/selinux/howdy_dm.te
@@ -1,4 +1,4 @@
-module howdy_gdm 1.0;
+module howdy_dm 1.0;
 
 require {
     type v4l_device_t, gdm_t, xdm_t, sddm_t, lightdm_t;


### PR DESCRIPTION
## Summary
- rename the SELinux policy source to howdy_dm.te and update the module declaration
- adjust the setup helper and container build to reference the new generic policy name

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9e141b1688321a5e8e0ca5799dfe7