### PR TITLE
feat: add linux-enable-ir-emitter for IR cameras

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -40,6 +40,14 @@ COPY systemd/howdy-pam.path /usr/lib/systemd/system/howdy-pam.path
 RUN ln -s ../howdy-selinux-install.service \
     /usr/lib/systemd/system/multi-user.target.wants/howdy-selinux-install.service
 
+# Install linux-enable-ir-emitter for cameras whose IR emitters don't activate
+# automatically on Linux. The systemd service re-enables the emitter after
+# every boot and suspend/resume cycle.
+ARG IR_EMITTER_VERSION=6.1.2
+ADD https://github.com/EmixamPP/linux-enable-ir-emitter/releases/download/${IR_EMITTER_VERSION}/linux-enable-ir-emitter-${IR_EMITTER_VERSION}-release.systemd.x86-64.tar.gz /tmp/ir-emitter.tar.gz
+RUN tar -C / --no-same-owner -xzf /tmp/ir-emitter.tar.gz && \
+    rm /tmp/ir-emitter.tar.gz
+
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \

--- a/Justfile
+++ b/Justfile
@@ -77,6 +77,20 @@ howdy-disable:
 howdy-status:
     /usr/libexec/howdy-pam status || true
 
+# Enable IR emitter service (activates at boot and after suspend/resume)
+howdy-ir-enable:
+    sudo systemctl enable --now linux-enable-ir-emitter.service
+    echo "IR emitter service enabled."
+
+# Disable IR emitter service
+howdy-ir-disable:
+    sudo systemctl disable --now linux-enable-ir-emitter.service
+    echo "IR emitter service disabled."
+
+# Show IR emitter service status
+howdy-ir-status:
+    systemctl status linux-enable-ir-emitter.service || true
+
 @howdy-camera-picker:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -108,6 +122,7 @@ howdy-status:
 
     echo "Trying each /dev/video* with howdy test (runs as root)"
     kept_paths=()
+    ir_configured=false
     for n in /dev/video*; do
         [ -e "$n" ] || continue
         PATH_TO_USE="$(pick_byid "$n")"
@@ -127,9 +142,41 @@ howdy-status:
             continue
         fi
 
-        # Show preview/log output so the human can judge quality
-        echo "$output"
-        echo
+        # Detect dark frames — offer to configure the IR emitter
+        if echo "$output" | grep -q "too dark"; then
+            echo "$output"
+            echo
+            if command -v linux-enable-ir-emitter &>/dev/null; then
+                read -r -p "Frames too dark — configure IR emitter for this device? [y/N/q] " ir_ans
+                case "${ir_ans:-n}" in
+                    y|Y)
+                        # Resolve /dev/v4l/by-id symlink to /dev/videoN for linux-enable-ir-emitter
+                        dev_node="$(readlink -f "$PATH_TO_USE")"
+                        echo "Running linux-enable-ir-emitter configure -d $dev_node ..."
+                        linux-enable-ir-emitter configure -d "$dev_node" || true
+                        echo
+                        echo "Retrying howdy test..."
+                        set_device "$PATH_TO_USE"
+                        if command -v timeout >/dev/null 2>&1; then
+                            output="$(sudo timeout 5s howdy test 2>&1 || true)"
+                        else
+                            output="$(sudo howdy test 2>&1 || true)"
+                        fi
+                        echo "$output"
+                        ir_configured=true
+                        ;;
+                    q|Q) echo "Quit requested."; exit 2 ;;
+                    *)   echo "Skipping $PATH_TO_USE"; continue ;;
+                esac
+            else
+                echo "$output"
+            fi
+            echo
+        else
+            echo "$output"
+            echo
+        fi
+
         read -r -p "Keep this candidate? [y/N/q] " ans
         case "${ans:-n}" in
             y|Y)
@@ -155,7 +202,6 @@ howdy-status:
             final="${kept_paths[0]}"
             echo "Only one candidate: $final"
             set_device "$final"
-            exit 0
             ;;
         *)
             echo
@@ -170,10 +216,25 @@ howdy-status:
                 final="${kept_paths[$idx]}"
                 echo "Final choice: $final"
                 set_device "$final"
-                exit 0
             else
                 echo "Invalid selection."
                 exit 3
             fi
             ;;
     esac
+
+    # If the IR emitter was configured during camera picking, offer to enable
+    # the systemd service so it persists across reboots and suspend/resume.
+    if [ "$ir_configured" = true ]; then
+        echo
+        if ! systemctl is-enabled linux-enable-ir-emitter.service &>/dev/null; then
+            read -r -p "Enable IR emitter service (activates at boot and after suspend)? [Y/n] " svc_ans
+            case "${svc_ans:-y}" in
+                n|N) echo "Skipped. You can enable later with: ujust howdy-ir-enable" ;;
+                *)   sudo systemctl enable --now linux-enable-ir-emitter.service
+                     echo "IR emitter service enabled." ;;
+            esac
+        else
+            echo "IR emitter service already enabled."
+        fi
+    fi

--- a/Justfile
+++ b/Justfile
@@ -77,20 +77,6 @@ howdy-disable:
 howdy-status:
     /usr/libexec/howdy-pam status || true
 
-# Enable IR emitter service (activates at boot and after suspend/resume)
-howdy-ir-enable:
-    sudo systemctl enable --now linux-enable-ir-emitter.service
-    echo "IR emitter service enabled."
-
-# Disable IR emitter service
-howdy-ir-disable:
-    sudo systemctl disable --now linux-enable-ir-emitter.service
-    echo "IR emitter service disabled."
-
-# Show IR emitter service status
-howdy-ir-status:
-    systemctl status linux-enable-ir-emitter.service || true
-
 @howdy-camera-picker:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -230,7 +216,7 @@ howdy-ir-status:
         if ! systemctl is-enabled linux-enable-ir-emitter.service &>/dev/null; then
             read -r -p "Enable IR emitter service (activates at boot and after suspend)? [Y/n] " svc_ans
             case "${svc_ans:-y}" in
-                n|N) echo "Skipped. You can enable later with: ujust howdy-ir-enable" ;;
+                n|N) echo "Skipped. Enable later with: sudo systemctl enable --now linux-enable-ir-emitter.service" ;;
                 *)   sudo systemctl enable --now linux-enable-ir-emitter.service
                      echo "IR emitter service enabled." ;;
             esac

--- a/README.md
+++ b/README.md
@@ -85,13 +85,7 @@ Interactively tests each `/dev/video*` device with `howdy test` and lets you pic
 
 Many IR cameras need their emitter explicitly enabled via a UVC control command. The camera picker (`ujust howdy-camera-picker`) detects this automatically — if frames are too dark, it offers to run [linux-enable-ir-emitter](https://github.com/EmixamPP/linux-enable-ir-emitter) to find the correct UVC control, then enables a systemd service to persist it across reboots and suspend/resume.
 
-To manage the IR emitter service separately:
-
-```bash
-ujust howdy-ir-enable     # Enable systemd service (activates at boot and after suspend/resume)
-ujust howdy-ir-disable    # Disable the service
-ujust howdy-ir-status     # Show service status
-```
+To manage the IR emitter service manually: `sudo systemctl enable|disable|status linux-enable-ir-emitter.service`.
 
 ---
 
@@ -129,4 +123,4 @@ sudo bootc switch localhost/blue-howdy:stable
 
 **All frames too dark / IR emitter not working**: Re-run `ujust howdy-camera-picker` — it will detect the dark frames and offer to configure the IR emitter automatically.
 
-**IR emitter stops working after sleep**: Ensure the systemd service is enabled: `ujust howdy-ir-enable`. The service automatically re-runs after every suspend/resume cycle.
+**IR emitter stops working after sleep**: Ensure the systemd service is enabled: `sudo systemctl enable --now linux-enable-ir-emitter.service`. It automatically re-runs after every suspend/resume cycle.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ ujust howdy-camera-picker
 
 Interactively tests each `/dev/video*` device with `howdy test` and lets you pick the right IR camera.
 
+### IR Emitter
+
+Many IR cameras need their emitter explicitly enabled via a UVC control command. The camera picker (`ujust howdy-camera-picker`) detects this automatically — if frames are too dark, it offers to run [linux-enable-ir-emitter](https://github.com/EmixamPP/linux-enable-ir-emitter) to find the correct UVC control, then enables a systemd service to persist it across reboots and suspend/resume.
+
+To manage the IR emitter service separately:
+
+```bash
+ujust howdy-ir-enable     # Enable systemd service (activates at boot and after suspend/resume)
+ujust howdy-ir-disable    # Disable the service
+ujust howdy-ir-status     # Show service status
+```
+
 ---
 
 ## How It Works
@@ -114,3 +126,7 @@ sudo bootc switch localhost/blue-howdy:stable
 **Wrong camera selected**: Run `ujust howdy-camera-picker` to select the correct IR camera.
 
 **Upgraded from an older image**: Run `ujust howdy-enable` to clean up stale PAM entries from previous versions (manual PAM editing, howdy-authselect, suspend hooks).
+
+**All frames too dark / IR emitter not working**: Re-run `ujust howdy-camera-picker` — it will detect the dark frames and offer to configure the IR emitter automatically.
+
+**IR emitter stops working after sleep**: Ensure the systemd service is enabled: `ujust howdy-ir-enable`. The service automatically re-runs after every suspend/resume cycle.


### PR DESCRIPTION
## Summary

- Installs [linux-enable-ir-emitter](https://github.com/EmixamPP/linux-enable-ir-emitter) v6.1.2 from the upstream GitHub release tarball
- Integrates IR emitter configuration into `ujust howdy-camera-picker` — when frames are too dark, it offers to scan UVC controls and enable the IR emitter
- After successful IR configuration, offers to enable the systemd service for boot and suspend/resume persistence

## Motivation

Many IR cameras (e.g. iContact Camera Pro, various Lenovo/Dell/Razer built-in IR cameras) don't automatically activate their IR emitter when the stream is opened on Linux. This causes howdy to report "all frames were too dark" — either on first setup or after suspend/resume when the USB controller resets.

`linux-enable-ir-emitter` is the standard tool for solving this. It brute-forces UVC camera controls to find the one that turns on the IR emitter, saves the configuration, and the included systemd service replays it at boot and after sleep.

## Test plan

- [ ] Build the image: `podman build -t blue-howdy:test .`
- [ ] Verify `linux-enable-ir-emitter` is at `/usr/local/bin/linux-enable-ir-emitter`
- [ ] Verify systemd service file is at `/etc/systemd/system/linux-enable-ir-emitter.service`
- [ ] Boot the image and run `ujust howdy-camera-picker` with an IR camera that has dark frames
- [ ] Confirm it detects dark frames and offers to configure the IR emitter
- [ ] Confirm it offers to enable the systemd service after configuration
- [ ] Suspend and resume — verify IR emitter reactivates and `sudo howdy test` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)